### PR TITLE
fix: pass `escapeHtml` to markdown

### DIFF
--- a/js/src/Cell/index.js
+++ b/js/src/Cell/index.js
@@ -14,6 +14,7 @@ import {
     StreamText,
     KernelOutputError,
 } from "@nteract/outputs";
+import Markdown from "./markdown";
 import { Provider as MathJaxProvider } from "@nteract/mathjax";
 
 import Widget from "./widget";
@@ -59,7 +60,7 @@ class DashboardCell extends React.Component {
         if (cell_type == "markdown") {
             contentEl = (
                 <Cell className={`md-cell ${classNames}`}>
-                    <Media.Markdown className={classNames} data={source} />
+                    <Markdown className={classNames} data={source} />
                 </Cell>
             );
         } else if (cell_type == "code") {
@@ -108,7 +109,7 @@ class DashboardCell extends React.Component {
                                         <Media.JavaScript />
                                         <Media.Json />
                                         <Media.LaTeX />
-                                        <Media.Markdown />
+                                        <Markdown />
                                         <Media.Plain />
                                     </RichMedia>
                                 );

--- a/js/src/Cell/markdown.js
+++ b/js/src/Cell/markdown.js
@@ -1,0 +1,20 @@
+import MarkdownComponent from "@nteract/markdown";
+import React from "react";
+
+/**
+ * @nteract/outputs does not set escapeHtml, so we pass it through here
+ */
+class Markdown extends React.Component {
+  render() {
+    return <MarkdownComponent source={this.props.data} escapeHtml={this.props.escapeHtml} />;
+  }
+}
+
+
+Markdown.defaultProps = {
+  data: "",
+  mediaType: "text/markdown",
+  escapeHtml: false,
+};
+
+export default Markdown;


### PR DESCRIPTION
`@nteract/outputs` doesn't allow us to propagate the `escapeHtml` prop to `MarkdownComponent`, which is required to render HTML in Markdown (as Jupyter does by default).

This PR just switches out the `@nteract/outputs` `Media.Markdown` component with our own that forwards the given prop, and sets the default to `True`.

I haven't thought through the ramifications of not escaping HTML too closely, I just know that I need it in my context.